### PR TITLE
[changinSecondsStats] feat(transactionStats): implementa escolha de faixa de tempo para estatísticas

### DIFF
--- a/src/main/java/com/bernardomerlo/controllers/TransactionStatsController.java
+++ b/src/main/java/com/bernardomerlo/controllers/TransactionStatsController.java
@@ -1,10 +1,13 @@
 package com.bernardomerlo.controllers;
 
 import com.bernardomerlo.entities.dtos.StatsDTO;
+import com.bernardomerlo.exceptions.InvalidTimeRangeException;
 import com.bernardomerlo.services.TransactionService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,8 +21,11 @@ public class TransactionStatsController {
     }
 
     @GetMapping
-    public ResponseEntity<StatsDTO> getStats(){
-        return ResponseEntity.ok(this.transactionService.getStats());
+    public ResponseEntity<StatsDTO> getStats(@RequestParam(required = false, defaultValue = "60") Integer seconds){
+        if(seconds <= 0){
+            throw new InvalidTimeRangeException("A faixa de tempo deve ser positiva e inteira.");
+        }
+        return ResponseEntity.ok(this.transactionService.getStats(seconds));
     }
 
 }

--- a/src/main/java/com/bernardomerlo/entities/TransactionStats.java
+++ b/src/main/java/com/bernardomerlo/entities/TransactionStats.java
@@ -26,8 +26,8 @@ public class TransactionStats {
         transactions.clear();
     }
 
-    public ArrayList<Transaction> getLastTransactions() {
-        LocalDateTime last60Seconds = LocalDateTime.now().minusSeconds(60);
+    public ArrayList<Transaction> getLastTransactions(Integer seconds) {
+        LocalDateTime last60Seconds = LocalDateTime.now().minusSeconds(seconds);
         ArrayList<Transaction> result = new ArrayList<>();
         for (Transaction t : transactions) {
             if(t.getWhenAdded().isAfter(last60Seconds)){

--- a/src/main/java/com/bernardomerlo/exceptions/InvalidTimeRangeException.java
+++ b/src/main/java/com/bernardomerlo/exceptions/InvalidTimeRangeException.java
@@ -1,0 +1,13 @@
+package com.bernardomerlo.exceptions;
+
+public class InvalidTimeRangeException extends RuntimeException{
+
+    public InvalidTimeRangeException(String message) {
+        super(message);
+    }
+
+    @Override
+    public String getMessage(){
+        return "A faixa de tempo deve ser positiva e inteira.";
+    }
+}

--- a/src/main/java/com/bernardomerlo/services/TransactionService.java
+++ b/src/main/java/com/bernardomerlo/services/TransactionService.java
@@ -53,10 +53,10 @@ public class TransactionService {
         transactions.delete();
     }
 
-    public StatsDTO getStats(){
+    public StatsDTO getStats(Integer seconds){
         long startTime = System.nanoTime();
         logger.debug("Iniciando cálculo de estatística");
-        ArrayList<Transaction> transactions =  this.transactions.getLastTransactions();
+        ArrayList<Transaction> transactions =  this.transactions.getLastTransactions(seconds);
 
         int count = 0;
         double sum = 0;

--- a/src/test/java/com/bernardomerlo/services/GetStatsTest.java
+++ b/src/test/java/com/bernardomerlo/services/GetStatsTest.java
@@ -27,9 +27,9 @@ class GetStatsTest {
 
     @Test
     public void testGetStatsWithEmptyList() {
-        when(transactionStats.getLastTransactions()).thenReturn(new ArrayList<>());
+        when(transactionStats.getLastTransactions(60)).thenReturn(new ArrayList<>());
 
-        StatsDTO statsDTO = transactionService.getStats();
+        StatsDTO statsDTO = transactionService.getStats(60);
 
         assertEquals(0, statsDTO.getCount());
         assertEquals(0.0, statsDTO.getSum());
@@ -45,9 +45,9 @@ class GetStatsTest {
         ArrayList<Transaction> arrayWithOneTransaction = new ArrayList<Transaction>();
         arrayWithOneTransaction.add(transaction);
 
-        when(transactionStats.getLastTransactions()).thenReturn(arrayWithOneTransaction);
+        when(transactionStats.getLastTransactions(60)).thenReturn(arrayWithOneTransaction);
 
-        StatsDTO statsDTO = transactionService.getStats();
+        StatsDTO statsDTO = transactionService.getStats(60);
 
         assertEquals(1, statsDTO.getCount());
         assertEquals(100.0, statsDTO.getSum());
@@ -67,9 +67,9 @@ class GetStatsTest {
 
         ArrayList<Transaction> arrayWithMultipleTransactions = new ArrayList<>(Arrays.asList(transaction, transaction1, transaction2, transaction3, transaction4, transaction5));
 
-        when(transactionStats.getLastTransactions()).thenReturn(arrayWithMultipleTransactions);
+        when(transactionStats.getLastTransactions(60)).thenReturn(arrayWithMultipleTransactions);
 
-        StatsDTO statsDTO = transactionService.getStats();
+        StatsDTO statsDTO = transactionService.getStats(60);
 
         assertEquals(6, statsDTO.getCount());
         assertEquals(21.0, statsDTO.getSum());

--- a/src/test/java/com/bernardomerlo/services/TransactionStatsTest.java
+++ b/src/test/java/com/bernardomerlo/services/TransactionStatsTest.java
@@ -38,7 +38,7 @@ public class TransactionStatsTest {
         transactionStats.add(validTransaction);
         transactionStats.add(invalidTransaction);
 
-        ArrayList<Transaction> lastTransactions = transactionStats.getLastTransactions();
+        ArrayList<Transaction> lastTransactions = transactionStats.getLastTransactions(60);
 
         assertEquals(1, lastTransactions.size(), "Deve haver apenas 1 transação recente");
         assertTrue(lastTransactions.contains(validTransaction), "Deve conter a transação recente");
@@ -51,15 +51,15 @@ public class TransactionStatsTest {
         Transaction validTransaction = new Transaction(100.0, OffsetDateTime.now().minusDays(1));
         transactionStats.add(validTransaction);
 
-        assertFalse(transactionStats.getLastTransactions().isEmpty(), "Deve haver uma transação");
+        assertFalse(transactionStats.getLastTransactions(60).isEmpty(), "Deve haver uma transação");
 
         transactionStats.delete();
 
-        assertTrue(transactionStats.getLastTransactions().isEmpty(), "Não deve haver nenhuma transação");
+        assertTrue(transactionStats.getLastTransactions(60).isEmpty(), "Não deve haver nenhuma transação");
 
         transactionStats.delete();
 
-        assertTrue(transactionStats.getLastTransactions().isEmpty(), "Não deve haver erro ao deletar com a lista vazia");
+        assertTrue(transactionStats.getLastTransactions(60).isEmpty(), "Não deve haver erro ao deletar com a lista vazia");
     }
 
 }


### PR DESCRIPTION
A rota agora aceita um parâmetro, que deve ser positivo e inteiro, que usa como base para fazer o cálculo da estatística. O valor não é obrigatório, então se ele não for passado, o valor padrão irá ser 60